### PR TITLE
Containerize App

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git
+.meteor/local
+node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+bundle/

--- a/.meteor/packages
+++ b/.meteor/packages
@@ -33,5 +33,5 @@ kadira:blaze-layout
 useraccounts:unstyled
 msolters:reactive-select
 tomwasd:flow-router-autoscroll
-force-ssl
 session
+force-ssl

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:8.9.3
+COPY ./bundle /bundle
+WORKDIR /bundle/programs/server
+RUN npm install
+
+WORKDIR /bundle
+ENV PORT=80
+ENV ROOT_URL=https://www.cryptometry.io
+CMD ["node", "main.js"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+.PHONY: cleanup build deploy
+
+cleanup:
+	rm -rf /tmp/build
+	rm -rf ./bundle
+
+build: cleanup
+	meteor build /tmp/build --architecture os.linux.x86_64
+	tar -xzf /tmp/build/crypto-portfolio-dashboard.tar.gz -C ./
+
+deploy:
+	heroku container:push web


### PR DESCRIPTION
Provides Makefile to build and deploy app as a docker container.

`make build` compiles the Meteor app into a local `./bundle/` dir.
`make deploy` uses `heroku` CLI to build and push the `Dockerfile` to the app instance.

This requires `heroku login` as well as `heroku container:login`

